### PR TITLE
Fix build for current RocksDB HEAD

### DIFF
--- a/rocksdb/_rocksdb.pyx
+++ b/rocksdb/_rocksdb.pyx
@@ -485,8 +485,8 @@ cdef class PySliceTransform(object):
     cdef object get_ob(self):
         return self.ob
 
-    cdef slice_transform.SliceTransform* get_transformer(self):
-        return <slice_transform.SliceTransform*> self.transfomer
+    cdef shared_ptr[slice_transform.SliceTransform] get_transformer(self):
+        return <shared_ptr[slice_transform.SliceTransform]> self.transfomer
 
     cdef set_info_log(self, shared_ptr[logger.Logger] info_log):
         self.transfomer.set_info_log(info_log)

--- a/rocksdb/options.pxd
+++ b/rocksdb/options.pxd
@@ -45,7 +45,7 @@ cdef extern from "rocksdb/options.h" namespace "rocksdb":
         CompressionType compression
         # TODO: compression_per_level
         # TODO: compression_opts
-        SliceTransform* prefix_extractor
+        shared_ptr[SliceTransform] prefix_extractor
         cpp_bool whole_key_filtering
         int num_levels
         int level0_file_num_compaction_trigger


### PR DESCRIPTION
The prefix_extractor in the options was changed from a raw pointer
to a smart pointer. It happened in RocksDB commit
8d007b4aaf581a54756759c58270eb6a4d70f472 [1](https://github.com/facebook/rocksdb/commit/8d007b4aaf581a54756759c58270eb6a4d70f472).
