### PR TITLE
Add lz4 and zstandard to installation instructions

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -12,7 +12,7 @@ For more details consider https://github.com/facebook/rocksdb/blob/master/INSTAL
 .. code-block:: bash
 
     apt-get install build-essential
-    apt-get install libsnappy-dev zlib1g-dev libbz2-dev libgflags-dev
+    apt-get install libgflags-dev libsnappy-dev zlib1g-dev libbz2-dev liblz4-dev libzstd-dev
     git clone https://github.com/facebook/rocksdb.git
     cd rocksdb
     make shared_lib


### PR DESCRIPTION
My pyrocksdb install failed with the error `/usr/bin/ld: cannot find -llz4`. Checking the [RocksDB Install Instructions](https://github.com/facebook/rocksdb/blob/master/INSTALL.md), it looks like `lz4` and `zstandard` also need to be installed.